### PR TITLE
fix: revert "chore(deps): bump actions/upload-artifact from 3 to 4"

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ runs:
         test -f ${{ inputs.name }}.tar && echo "${{ inputs.name }}.tar created" || echo "No files found"
 
     - name: '📤 upload artifact'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.name }}.tar


### PR DESCRIPTION
Reverts eviden-actions/upload-artifact#119

Necessary to keep compatibility with GES